### PR TITLE
npm run serve -> npm start to follow the convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ https://toxicfork.github.com/react-three-renderer-example/
 
 #### Installation
 ``
-npm i
+npm install
 ``
 #### Local server
 ``
-npm run serve
+npm start
 ``
 
 Then visit [http://localhost:8080](http://localhost:8080) on your favorite webgl-enabled browser :)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An example showing how to use the react-three-renderer package",
   "main": "index.js",
   "scripts": {
-    "serve": "gulp webpack-dev-server",
+    "start": "gulp webpack-dev-server",
     "eslint-internal": "eslint ./src/",
     "eslint": "npm run eslint-internal -loglevel silent || true",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- npm i -> npm install to improve clarity of README
  (experienced developers know the shortcut anyway)
